### PR TITLE
Handle schema sites not using [itemprop=name] for author

### DIFF
--- a/lib/hangry/schema_org_recipe_parser.rb
+++ b/lib/hangry/schema_org_recipe_parser.rb
@@ -34,8 +34,10 @@ module Hangry
       author_node = node_with_itemprop(:author)
       if author_node['itemtype'] == 'http://schema.org/Person'
         author = author_node.css('[itemprop=name]')
+        name = author.first['content'].to_s if author.present?
       end
-      author.present? ? author.first['content'].to_s : author_node.content.to_s
+      name = author_node.content.to_s unless name
+      name
     end
     def parse_cook_time
       parse_time(:cookTime)

--- a/lib/hangry/schema_org_recipe_parser.rb
+++ b/lib/hangry/schema_org_recipe_parser.rb
@@ -32,12 +32,10 @@ module Hangry
     end
     def parse_author
       author_node = node_with_itemprop(:author)
-      author = if author_node['itemtype'] == "http://schema.org/Person"
-        author_node.css('[itemprop = "name"]').first['content']
-      else
-        author_node.content
+      if author_node['itemtype'] == 'http://schema.org/Person'
+        author = author_node.css('[itemprop=name]')
       end
-      author
+      author.present? ? author.first['content'] : author_node.content
     end
     def parse_cook_time
       parse_time(:cookTime)

--- a/lib/hangry/schema_org_recipe_parser.rb
+++ b/lib/hangry/schema_org_recipe_parser.rb
@@ -35,7 +35,7 @@ module Hangry
       if author_node['itemtype'] == 'http://schema.org/Person'
         author = author_node.css('[itemprop=name]')
       end
-      author.present? ? author.first['content'] : author_node.content
+      author.present? ? author.first['content'].to_s : author_node.content.to_s
     end
     def parse_cook_time
       parse_time(:cookTime)

--- a/lib/hangry/version.rb
+++ b/lib/hangry/version.rb
@@ -1,3 +1,3 @@
 module Hangry
-  VERSION = "0.0.13"
+  VERSION = "0.0.14"
 end


### PR DESCRIPTION
**Current issue:**
Some sites use the "Person" Schema don't have an `[itemprop=name]` referencing the author's name.

**Fix:**
Check for the presence of the `[itemprop=name]` attribute, and use the parent/author node's content as a fallback.

**Example:**
If you feed Hangry a URL like http://www.foodnetwork.com/recipes/a-bowl-of-gluten-free-oatmeal-recipe.html, it will choke. 😲